### PR TITLE
-  Text Extensions:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.4.2
+
+- **Text Extensions:**
+    - Renamed `align` → `textAlign` for better clarity.
+    - Renamed `decoration` → `textDecoration` to avoid conflict with widget extension.
+
+
 ### 1.4.1
 
 - **Removed:**

--- a/lib/extensions/ui/text_style_extension.dart
+++ b/lib/extensions/ui/text_style_extension.dart
@@ -75,7 +75,7 @@ extension TextStyleExtension on Text {
   }
 
   /// Applies the given [decoration] to the text's decoration.
-  Text decoration(TextDecoration decoration) {
+  Text textDecoration(TextDecoration decoration) {
     return _copyWith(
       style:
           style?.copyWith(decoration: decoration) ??
@@ -92,7 +92,7 @@ extension TextStyleExtension on Text {
   /// - `TextAlign.center`: Centers the text horizontally.
   /// - `TextAlign.right`: Aligns the text to the right.
   /// - `TextAlign.justify`: Justifies the text, spreading it to fill the width.
-  Text align(TextAlign align) => _copyWith(textAlign: align);
+  Text textAlign(TextAlign align) => _copyWith(textAlign: align);
 
   /// Sets the maximum number of lines for the text.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extensions_plus
 description: "This package provides a powerful collection of extensions for Dart's core types, enabling cleaner and more expressive code."
-version: 1.4.1
+version: 1.4.2
 homepage: "https://github.com/azharbinanwar/extensions_plus"
 
 environment:


### PR DESCRIPTION
    - Renamed `align` → `textAlign` for better clarity.
    - Renamed `decoration` → `textDecoration` to avoid conflict with widget extension.