### PR TITLE
feat!: resolve all conflicts with popular packages (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+### 1.5.0
+
+- **Breaking Changes:**
+    - **Navigation Extensions:** Renamed navigation methods to avoid conflicts with popular packages like `go_router`.
+        - `push()` → `pushPlus()`
+        - `pop()` → `goBack()`
+        - `popUntil()` → `goBackUntil()`
+        - `canPop` → `canGoBack`
+        - `popUntilFirst()` → `goBackToFirst()`
+        - `popWithData()` → `goBackWithData()`
+        - `popTimes()` → `goBackTimes()`
+    - **List Extensions:** Renamed list methods to avoid conflicts with the `collection` package.
+        - `firstWhereOrNull()` → `findFirst()`
+        - `elementAtOrNull()` → `getAt()`
+    - **Iterable Extensions:** Renamed iterable methods to avoid conflicts with the `collection` package.
+        - `firstWhereOrNull()` → `findFirst()`
+        - `elementAtOrNull()` → `getAt()`
+
+- **Migration Guide:**
+    - Update all `context.push()` calls to `context.pushPlus()`
+    - Update all `context.pop()` calls to `context.goBack()`
+    - Update all `list.firstWhereOrNull()` calls to `list.findFirst()`
+    - Update all `list.elementAtOrNull()` calls to `list.getAt()`
+    - Update all `iterable.firstWhereOrNull()` calls to `iterable.findFirst()`
+    - Update all `iterable.elementAtOrNull()` calls to `iterable.getAt()`
+    - Update other navigation methods accordingly
+
+- **Documentation:**
+    - Updated README with new method names and examples
+    - Added migration guide for users upgrading from v1.4.x
+    - Updated all code examples throughout documentation
+
+- **Reason for Changes:**
+    - Resolves **all conflicts** with popular packages (`go_router`, `collection`)
+    - Allows developers to use multiple packages together without import conflicts
+    - Maintains all existing functionality with new, conflict-free naming
+    - Package now works seamlessly alongside the most popular Flutter routing and utility packages
+
+
 ### 1.4.3
 
 - **SDK Updates:**

--- a/README.md
+++ b/README.md
@@ -139,27 +139,27 @@ The `NavigationExtension` enhances the `BuildContext` in Flutter, providing a ri
 ## Features
 
 - **Shorthand Access**
-    - Quickly access the current `NavigatorState` using `context.navigator`.
+  - Quickly access the current `NavigatorState` using `context.navigator`.
 
 - **Flexible Navigation**
-    - Push new routes with full control over `MaterialPageRoute` properties using `context.push()` or `context.pushAndRemoveUntil()`.
+  - Push new routes with full control over `MaterialPageRoute` properties using `context.pushPlus()` or `context.pushAndRemoveUntil()`.
 
 - **Custom Transitions**
-    - Smooth fade transitions with `context.pushWithFade()`.
-    - Directional slide transitions with `context.pushWithSlide()`.
+  - Smooth fade transitions with `context.pushWithFade()`.
+  - Directional slide transitions with `context.pushWithSlide()`.
 
 - **Route Management**
-    - Remove specific or multiple routes using `context.popUntilFirst()` and `context.popTimes()`.
-    - Check if a specific route exists with `context.hasRoute()`.
+  - Remove specific or multiple routes using `context.goBackToFirst()` and `context.goBackTimes()`.
+  - Check if a specific route exists with `context.hasRoute()`.
 
 - **State Passing**
-    - Pass and retrieve data between routes using `context.popWithData()`.
+  - Pass and retrieve data between routes using `context.goBackWithData()`.
 
 ## Usage Examples
 
 ### Push a New Route
 ```dart
-context.push(
+context.pushPlus(
   HomePage(),
   fullscreenDialog: true,
   settings: RouteSettings(name: '/home'),
@@ -192,10 +192,10 @@ context.pushWithSlide(
 );
 ```
 
-### Pop with Data
+### Go Back with Data
 
 ```dart
-context.popWithData({'result':'success'};
+context.goBackWithData({'result': 'success'});
 ```
 
 ### Check if a Route Exists
@@ -206,23 +206,46 @@ if (context.hasRoute('/home')) {
 }
 ```
 
-### Pop Multiple Routes
+### Go Back Multiple Routes
 
 ```dart
-context.popTimes(2); // Pops two routes
+context.goBackTimes(2); // Goes back two routes
+```
+
+### Simple Navigation
+```dart
+context.goBack(); // Simple go back
+context.goBack('result'); // Go back with result
+
+// Check if can go back
+if (context.canGoBack) {
+  context.goBack();
+}
+```
+
+## Migration from v1.4.x to v1.5.0
+
+If you're upgrading from a previous version, update your method calls:
+
+```dart
+// Old (v1.4.x)           →  New (v1.5.0)
+context.push()            →  context.pushPlus()
+context.pop()             →  context.goBack()
+context.popWithData()     →  context.goBackWithData()
+context.popTimes()        →  context.goBackTimes()
+context.canPop            →  context.canGoBack
 ```
 
 ## Why Use NavigationExtension?
 
-- Simplifies navigation tasks with clean, reusable methods.
-- Reduces boilerplate code for custom transitions and complex navigation flows.
-- Enhances code readability and consistency.
+- **Conflict-free**: Works alongside popular packages like `go_router` without import conflicts.
+- **Intuitive naming**: Clear, descriptive method names that express intent.
+- **Simplifies navigation**: Reduces boilerplate code for custom transitions and complex navigation flows.
+- **Enhanced readability**: Consistent API that improves code maintainability.
 
+**Note:** This extension is designed to work seamlessly with `Navigator` in Flutter and supports both material and custom page transitions. All navigation methods are prefixed to avoid conflicts with other popular routing packages.
 
-**Note:** This extensions is designed to work seamlessly with `Navigator` in Flutter and supports
-both material and custom page transitions.
 ---
-
 
 # Theme
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,43 +43,43 @@ class ExtensionUsagePage extends StatelessWidget {
           children: [
             ListTile(
               title: const Text('Theme Extension'),
-              onTap: () => context.push(ThemeExtensionPage()),
+              onTap: () => context.pushPlus(ThemeExtensionPage()),
             ),
             ListTile(
               title: const Text('Color Extension'),
-              onTap: () => context.push(ColorExtensionPage()),
+              onTap: () => context.pushPlus(ColorExtensionPage()),
             ),
             ListTile(
               title: const Text('Navigation'),
-              onTap: () => context.push(NavigatorPage()),
+              onTap: () => context.pushPlus(NavigatorPage()),
             ),
             ListTile(
               title: const Text('Map extension'),
-              onTap: () => context.push(MapExtensionPage()),
+              onTap: () => context.pushPlus(MapExtensionPage()),
             ),
             ListTile(
               title: const Text('List extension'),
-              onTap: () => context.push(ListExtensionPage()),
+              onTap: () => context.pushPlus(ListExtensionPage()),
             ),
             ListTile(
               title: const Text('Num extension'),
-              onTap: () => context.push(NumericExtensionDemoPage()),
+              onTap: () => context.pushPlus(NumericExtensionDemoPage()),
             ),
             ListTile(
               title: const Text('DateTime extension'),
-              onTap: () => context.push(DateTimeExtensionDemoPage()),
+              onTap: () => context.pushPlus(DateTimeExtensionDemoPage()),
             ),
             ListTile(
               title: const Text('Widget extension'),
-              onTap: () => context.push(WidgetExtensionDemo()),
+              onTap: () => context.pushPlus(WidgetExtensionDemo()),
             ),
             ListTile(
               title: const Text('String extension'),
-              onTap: () => context.push(StringExtensionPage()),
+              onTap: () => context.pushPlus(StringExtensionPage()),
             ),
             ListTile(
               title: const Text('Text Style extension'),
-              onTap: () => context.push(TextStyleDemoPage()),
+              onTap: () => context.pushPlus(TextStyleDemoPage()),
             ),
           ],
         ),

--- a/example/lib/navigator_page.dart
+++ b/example/lib/navigator_page.dart
@@ -14,7 +14,7 @@ class NavigatorPage extends StatelessWidget {
           children: [
             ListTile(
               title: const Text('Navigator Extension'),
-              onTap: () => context.push(FirstPage()),
+              onTap: () => context.pushPlus(FirstPage()),
             ),
 
             // with transitions
@@ -42,7 +42,7 @@ class FirstPage extends StatelessWidget {
         appBar: AppBar(title: Text('First Page')),
         body: Center(
           child: ElevatedButton(
-            onPressed: () => context.push(SecondPage()),
+            onPressed: () => context.pushPlus(SecondPage()),
             child: Text('Go to Second Page'),
           ),
         ),
@@ -57,7 +57,7 @@ class SecondPage extends StatelessWidget {
         appBar: AppBar(title: Text('Second Page')),
         body: Center(
           child: ElevatedButton(
-            onPressed: () => context.pop(),
+            onPressed: () => context.goBack(),
             child: Text('Go Back'),
           ),
         ),

--- a/example/lib/pages/list_extension_page.dart
+++ b/example/lib/pages/list_extension_page.dart
@@ -140,7 +140,7 @@ class _ListExtensionPageState extends State<ListExtensionPage> {
   }
 
   Widget _buildFirstWhereSection() {
-    final firstUser = _users.firstWhereOrNull((u) => u['city'] == 'New York');
+    final firstUser = _users.findFirst((u) => u['city'] == 'New York');
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/extensions/build_context/build_context_navigation.dart
+++ b/lib/extensions/build_context/build_context_navigation.dart
@@ -23,13 +23,13 @@ extension NavigationExtension on BuildContext {
   ///
   /// Example:
   /// ```dart
-  /// context.push(
+  /// context.pushPlus(
   ///   HomePage(),
   ///   fullscreenDialog: true,
   ///   settings: RouteSettings(name: '/home'),
   /// );
   /// ```
-  Future<T?> push<T>(
+  Future<T?> pushPlus<T>(
     Widget page, {
     bool maintainState = true,
     bool fullscreenDialog = false,
@@ -56,7 +56,7 @@ extension NavigationExtension on BuildContext {
   /// Parameters:
   /// - [page]: The widget to display in the new route
   /// - [predicate]: Function that determines which routes to keep
-  /// - Additional [MaterialPageRoute] properties as described in [push]
+  /// - Additional [MaterialPageRoute] properties as described in [pushPlus]
   ///
   /// Example:
   /// ```dart
@@ -101,7 +101,7 @@ extension NavigationExtension on BuildContext {
   /// Parameters:
   /// - [page]: The widget to display in the new route
   /// - [duration]: Duration of the fade animation (defaults to 300ms)
-  /// - Additional [MaterialPageRoute] properties as described in [push]
+  /// - Additional [MaterialPageRoute] properties as described in [pushPlus]
   ///
   /// Example:
   /// ```dart
@@ -142,7 +142,7 @@ extension NavigationExtension on BuildContext {
   /// - [page]: The widget to display in the new route
   /// - [duration]: Duration of the slide animation (defaults to 300ms)
   /// - [begin]: Starting offset for the slide animation (defaults to right-to-left)
-  /// - Additional [MaterialPageRoute] properties as described in [push]
+  /// - Additional [MaterialPageRoute] properties as described in [pushPlus]
   ///
   /// Example:
   /// ```dart
@@ -185,47 +185,47 @@ extension NavigationExtension on BuildContext {
     );
   }
 
-  /// Pops the current route off the navigation stack.
+  /// Goes back by popping the current route off the navigation stack.
   ///
   /// Optionally returns a [result] to the previous route.
   ///
   /// Example:
   /// ```dart
-  /// context.pop(); // Simple pop
-  /// context.pop('result'); // Pop with result
+  /// context.goBack(); // Simple go back
+  /// context.goBack('result'); // Go back with result
   /// ```
-  void pop<T>([T? result]) => navigator.pop<T>(result);
+  void goBack<T>([T? result]) => navigator.pop<T>(result);
 
-  /// Pops routes until [predicate] returns true.
+  /// Goes back until [predicate] returns true.
   ///
   /// Example:
   /// ```dart
-  /// context.popUntil((route) => route.isFirst); // Pop to first route
+  /// context.goBackUntil((route) => route.isFirst); // Go back to first route
   /// ```
-  void popUntil(bool Function(Route) predicate) =>
+  void goBackUntil(bool Function(Route) predicate) =>
       navigator.popUntil(predicate);
 
-  /// Whether the navigator can pop the current route.
-  bool get canPop => navigator.canPop();
+  /// Whether the navigator can go back (pop the current route).
+  bool get canGoBack => navigator.canPop();
 
-  /// Pops all routes except the first route.
-  void popUntilFirst() => navigator.popUntil((route) => route.isFirst);
+  /// Goes back to the first route (pops all routes except the first).
+  void goBackToFirst() => navigator.popUntil((route) => route.isFirst);
 
-  /// Pops the current route and returns [data] to the previous route.
+  /// Goes back and returns [data] to the previous route.
   ///
   /// Example:
   /// ```dart
-  /// context.popWithData({'result': 'success'});
+  /// context.goBackWithData({'result': 'success'});
   /// ```
-  void popWithData<T>(T data) => navigator.pop<T>(data);
+  void goBackWithData<T>(T data) => navigator.pop<T>(data);
 
-  /// Pops multiple routes at once.
+  /// Goes back multiple routes at once.
   ///
   /// Example:
   /// ```dart
-  /// context.popTimes(2); // Pop two routes
+  /// context.goBackTimes(2); // Go back two routes
   /// ```
-  void popTimes(int times) {
+  void goBackTimes(int times) {
     int count = 0;
     navigator.popUntil((_) => count++ >= times);
   }

--- a/lib/extensions/build_context/overlay_utilities_build_context.dart
+++ b/lib/extensions/build_context/overlay_utilities_build_context.dart
@@ -111,17 +111,16 @@ extension OverlayUtilitiesBuildContext on BuildContext {
     required Widget child,
     EdgeInsetsGeometry padding = const EdgeInsets.all(16.0),
   }) {
-    List<Widget> userActions =
-        actions.length <= 1
-            ? actions
-            : actions
-                .map(
-                  (e) => Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                    child: e,
-                  ),
-                )
-                .toList();
+    List<Widget> userActions = actions.length <= 1
+        ? actions
+        : actions
+              .map(
+                (e) => Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  child: e,
+                ),
+              )
+              .toList();
     return showGeneralDialog(
       context: this,
       barrierColor: barrierColor ?? Colors.transparent,

--- a/lib/extensions/collections/iterable_extension.dart
+++ b/lib/extensions/collections/iterable_extension.dart
@@ -50,9 +50,9 @@ extension IterableExtension<T> on Iterable<T> {
 
   /// Returns element at index or null if out of bounds.
   ///
-  /// [1, 2, 3].elementAtOrNull(5) // null
-  /// [1, 2, 3].elementAtOrNull(1) // 2
-  T? elementAtOrNull(int index) {
+  /// [1, 2, 3].getAt(5) // null
+  /// [1, 2, 3].getAt(1) // 2
+  T? getAt(int index) {
     if (index < 0) return null;
     var i = 0;
     for (final element in this) {
@@ -64,9 +64,9 @@ extension IterableExtension<T> on Iterable<T> {
 
   /// Returns first element matching predicate or null.
   ///
-  /// [1, 2, 3].firstWhereOrNull((e) => e > 5) // null
-  /// [1, 2, 3].firstWhereOrNull((e) => e > 1) // 2
-  T? firstWhereOrNull(bool Function(T) test) {
+  /// [1, 2, 3].findFirst((e) => e > 5) // null
+  /// [1, 2, 3].findFirst((e) => e > 1) // 2
+  T? findFirst(bool Function(T) test) {
     for (final element in this) {
       if (test(element)) return element;
     }

--- a/lib/extensions/collections/list_extension.dart
+++ b/lib/extensions/collections/list_extension.dart
@@ -22,7 +22,7 @@ extension ListExtension<T> on List<T> {
   ///
   /// [predicate] Condition to match
   /// [Returns] First matching element or null
-  T? firstWhereOrNull(bool Function(T) predicate) {
+  T? findFirst(bool Function(T) predicate) {
     for (final element in this) {
       if (predicate(element)) {
         return element;
@@ -74,7 +74,7 @@ extension ListExtension<T> on List<T> {
   ///
   /// [index] Index to access
   /// [Returns] Element at index or null
-  T? elementAtOrNull(int index) {
+  T? getAt(int index) {
     return (index >= 0 && index < length) ? this[index] : null;
   }
 

--- a/lib/extensions/data_types/string_text_style_extension.dart
+++ b/lib/extensions/data_types/string_text_style_extension.dart
@@ -210,8 +210,9 @@ extension StringTextStyleExtension on String {
     int? maxLines,
     TextOverflow? overflow,
   }) {
-    TextStyle? baseStyle =
-        context != null ? Theme.of(context).textTheme.bodyMedium : null;
+    TextStyle? baseStyle = context != null
+        ? Theme.of(context).textTheme.bodyMedium
+        : null;
 
     return Text(
       this,


### PR DESCRIPTION
BREAKING CHANGES:
- Renamed navigation methods to avoid conflicts with go_router
  * push() → pushPlus()
  * pop() → goBack()
  * popUntil() → goBackUntil()
  * canPop → canGoBack
  * popUntilFirst() → goBackToFirst()
  * popWithData() → goBackWithData()
  * popTimes() → goBackTimes()
- Renamed list/iterable methods to avoid conflicts with collection package
  * firstWhereOrNull() → findFirst()
  * elementAtOrNull() → getAt()
- Updated documentation and examples with new method names
- Added migration guide in README