### PR TITLE
resolved issues for flutter 3.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 1.6.0
+
+- **SDK Updates:**
+    - Updated flutter constraint to `>=3.35.0` for flutter 3.35.0 compatibility.
+
+- **Bug Fixes:**
+    - Replaced deprecated `AppBarTheme` with `AppBarThemeData`Data` in `BuildContextTheme`.
+    - Replaced deprecated `BottomAppBarTheme` with `BottomAppBarTheme`Data` in `BuildContextTheme`.
+    - Replaced deprecated `InputDecorationTheme` with `InputDecorationThemeData`Data` in `GenericBuildContextExtension`.
+
 ### 1.5.0
 
 - **Breaking Changes:**

--- a/lib/extensions/build_context/build_context_theme.dart
+++ b/lib/extensions/build_context/build_context_theme.dart
@@ -228,8 +228,8 @@ extension BuildContextTheme on BuildContext {
   /// Returns the surfaceTint color from the current theme.
   Color get surfaceTint => Theme.of(this).colorScheme.surfaceTint;
 
-  /// AppBar Theme
-  AppBarTheme get appBarTheme => Theme.of(this).appBarTheme;
+  /// AppBar Theme Data
+  AppBarThemeData get appBarTheme => Theme.of(this).appBarTheme;
 
   /// Access the app bar color of the current theme.
   Color get appBarColor => Theme.of(this).appBarTheme.backgroundColor!;
@@ -302,8 +302,8 @@ extension BuildContextTheme on BuildContext {
   /// Retrieves the [MaterialBannerThemeData] for material banners.
   MaterialBannerThemeData get bannerTheme => Theme.of(this).bannerTheme;
 
-  /// Retrieves the [BottomAppBarTheme] for bottom app bars.
-  BottomAppBarTheme get bottomAppBarTheme => Theme.of(this).bottomAppBarTheme;
+  /// Retrieves the [BottomAppBarThemeData] for bottom app bars.
+  BottomAppBarThemeData get bottomAppBarTheme => Theme.of(this).bottomAppBarTheme;
 
   /// Retrieves the [BottomNavigationBarThemeData] for bottom navigation bars.
   BottomNavigationBarThemeData get bottomNavigationBarTheme =>

--- a/lib/extensions/build_context/generic_build_context_extension.dart
+++ b/lib/extensions/build_context/generic_build_context_extension.dart
@@ -17,8 +17,8 @@ extension GenericBuildContextExtension on BuildContext {
   Map<Object, ThemeExtension<dynamic>> get extensions =>
       Theme.of(this).extensions;
 
-  /// Retrieve the `InputDecorationTheme`.
-  InputDecorationTheme get inputDecorationTheme =>
+  /// Retrieve the `InputDecorationThemeData`.
+  InputDecorationThemeData get inputDecorationTheme =>
       Theme.of(this).inputDecorationTheme;
 
   /// Access the `MaterialTapTargetSize`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: extensions_plus
 description: "This package provides a powerful collection of extensions for Dart's core types, enabling cleaner and more expressive code."
-version: 1.5.0
+version: 1.6.0
 homepage: "https://github.com/azharbinanwar/extensions_plus"
 
 environment:
   sdk: ^3.8.0
-  flutter: ">=1.17.0"
+  flutter: ">=3.35.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This pull request fixes the issues with flutter 3.35.

This are the changes:

### 1.6.0

- **SDK Updates:**
    - Updated flutter constraint to `>=3.35.0` for flutter 3.35.0 compatibility.

- **Bug Fixes:**
    - Replaced deprecated `AppBarTheme` with `AppBarThemeData`Data` in `BuildContextTheme`.
    - Replaced deprecated `BottomAppBarTheme` with `BottomAppBarTheme`Data` in `BuildContextTheme`.
    - Replaced deprecated `InputDecorationTheme` with `InputDecorationThemeData`Data` in `GenericBuildContextExtension`.